### PR TITLE
History State and ViewModel update

### DIFF
--- a/app/src/main/java/com/stephens/diceroller/DiceRollerAppComposable.kt
+++ b/app/src/main/java/com/stephens/diceroller/DiceRollerAppComposable.kt
@@ -15,7 +15,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavDestination.Companion.hasRoute
 import androidx.navigation.NavDestination.Companion.hierarchy
 import androidx.navigation.NavGraph.Companion.findStartDestination
@@ -27,7 +26,6 @@ import androidx.navigation.compose.rememberNavController
 import com.stephens.diceroller.common.TopLevelRoute
 import com.stephens.diceroller.history.HistoryScreen
 import com.stephens.diceroller.main.MainScreen
-import com.stephens.diceroller.main.MainViewModel
 import com.stephens.diceroller.settings.SettingsScreen
 import kotlinx.serialization.Serializable
 
@@ -39,10 +37,7 @@ data object Settings
 data object History
 
 @Composable
-fun DiceRollerAppComposable(
-    viewModel: MainViewModel = viewModel(),
-    navController: NavHostController = rememberNavController()
-) {
+fun DiceRollerAppComposable(navController: NavHostController = rememberNavController()) {
     val topLevelRoutes = listOf(
         //TODO: Implement Settings screens
         TopLevelRoute(stringResource(R.string.home), Home, Icons.Default.Home),
@@ -81,13 +76,13 @@ fun DiceRollerAppComposable(
                 .padding(innerPadding)
         ) {
             composable<Home> {
-                MainScreen(viewModel)
+                MainScreen()
             }
             composable<Settings>{
                 SettingsScreen()
             }
             composable<History> {
-                HistoryScreen(viewModel)
+                HistoryScreen()
             }
         }
     }

--- a/app/src/main/java/com/stephens/diceroller/history/HistoryScreen.kt
+++ b/app/src/main/java/com/stephens/diceroller/history/HistoryScreen.kt
@@ -9,37 +9,44 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Button
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.stephens.diceroller.R
 import com.stephens.diceroller.data.RollResult
-import com.stephens.diceroller.main.MainAction
-import com.stephens.diceroller.main.MainViewModel
 import java.time.Instant
 import java.time.LocalDateTime
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 
 @Composable
-fun HistoryScreen(viewModel: MainViewModel) {
-    val uiState = viewModel.historyStateFlow.collectAsState(emptyList())
-    HistoryContent(uiState.value) { viewModel.postAction(MainAction.TapClearHistory) }
+fun HistoryScreen(viewModel: HistoryViewModel = hiltViewModel<HistoryViewModel>()) {
+    val uiState = viewModel.stateFlow.collectAsStateWithLifecycle()
+    HistoryContent(uiState.value) {
+        viewModel.postAction(HistoryAction.TapClearHistory)
+    }
 }
 
 @Composable
-fun HistoryContent(rollResults: List<RollResult>, clearHistory: () -> Unit) {
+fun HistoryContent(
+    state: HistoryState,
+    clearHistory: () -> Unit
+) {
     Column(modifier = Modifier.fillMaxSize()) {
         Button(
             onClick = { clearHistory() },
@@ -47,8 +54,15 @@ fun HistoryContent(rollResults: List<RollResult>, clearHistory: () -> Unit) {
                 .align(Alignment.CenterHorizontally)
                 .padding(8.dp)
         ) { Text(stringResource(R.string.clear_history)) }
-        LazyColumn(reverseLayout = true) {
-            items(rollResults) { rollResult ->
+
+        //The list of results is reversed to bring the most recent result to the top
+        //Since the list is reversed we scroll to the "lastIndex", which is the most
+        //recent and top of the list
+        LazyColumn(
+            reverseLayout = true,
+            state = LazyListState(firstVisibleItemIndex = state.rollResults.lastIndex)
+        ) {
+            items(state.rollResults) { rollResult ->
                 RollResultCard(rollResult)
             }
         }
@@ -56,18 +70,15 @@ fun HistoryContent(rollResults: List<RollResult>, clearHistory: () -> Unit) {
 }
 
 @Composable
-fun RollResultCard(
-    rollResult: RollResult,
-    modifier: Modifier = Modifier
-) {
+fun RollResultCard(rollResult: RollResult) {
     ElevatedCard(
         elevation = CardDefaults.cardElevation(
             defaultElevation = 6.dp
         ),
         colors = CardDefaults.cardColors(
-            containerColor = Color.White
+            containerColor = MaterialTheme.colorScheme.surface
         ),
-        modifier = modifier
+        modifier = Modifier
             .fillMaxWidth()
             .height(IntrinsicSize.Min)
             .padding(4.dp)
@@ -86,7 +97,8 @@ fun RollResultCard(
             }
             Text(
                 text = "Result",
-                modifier = Modifier.align(Alignment.CenterHorizontally))
+                modifier = Modifier.align(Alignment.CenterHorizontally)
+            )
             Text(
                 text = rollResult.result.toString(),
                 modifier = Modifier
@@ -98,9 +110,27 @@ fun RollResultCard(
     }
 }
 
-private fun formatDate(timeInMillis: Long, context: Context): String{
+private fun formatDate(timeInMillis: Long, context: Context): String {
     val formatter = DateTimeFormatter.ofPattern(context.getString(R.string.date_format))
     val instant = Instant.ofEpochMilli(timeInMillis)
     val date = LocalDateTime.ofInstant(instant, ZoneId.systemDefault())
     return formatter.format(date)
+}
+
+@Preview
+@Composable
+fun HistoryScreenPreview() {
+    val rollResult = listOf(
+        RollResult(
+            time = 1728013121240,
+            result = 6,
+            sides = 6
+        ),
+        RollResult(
+            time = 1728013122100,
+            result = 3,
+            sides = 6
+        )
+    )
+    HistoryContent(state = HistoryState(rollResults = rollResult)) {}
 }

--- a/app/src/main/java/com/stephens/diceroller/history/HistoryState.kt
+++ b/app/src/main/java/com/stephens/diceroller/history/HistoryState.kt
@@ -1,0 +1,11 @@
+package com.stephens.diceroller.history
+
+import com.stephens.diceroller.data.RollResult
+
+data class HistoryState(
+    val rollResults: List<RollResult> = emptyList()
+)
+
+sealed class HistoryAction {
+    data object TapClearHistory: HistoryAction()
+}

--- a/app/src/main/java/com/stephens/diceroller/history/HistoryViewModel.kt
+++ b/app/src/main/java/com/stephens/diceroller/history/HistoryViewModel.kt
@@ -1,0 +1,45 @@
+package com.stephens.diceroller.history
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.stephens.diceroller.data.HistoryRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class HistoryViewModel @Inject constructor(
+    private val historyRepository: HistoryRepository
+): ViewModel() {
+    private var state = HistoryState()
+        private set(value) {
+            field = value
+            _stateFlow.tryEmit(value)
+        }
+
+    private val _stateFlow = MutableStateFlow(state)
+    val stateFlow = _stateFlow.asStateFlow()
+
+    init {
+        viewModelScope.launch(Dispatchers.IO) {
+            historyRepository.getHistory().collect { rollResult ->
+                state = state.copy(rollResults = rollResult)
+            }
+        }
+    }
+
+    fun postAction(action: HistoryAction) {
+        when(action) {
+            HistoryAction.TapClearHistory -> clearHistory()
+        }
+    }
+
+    private fun clearHistory() {
+        viewModelScope.launch(Dispatchers.IO) {
+            historyRepository.clearHistory()
+        }
+    }
+}

--- a/app/src/main/java/com/stephens/diceroller/main/MainScreen.kt
+++ b/app/src/main/java/com/stephens/diceroller/main/MainScreen.kt
@@ -15,7 +15,6 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -23,17 +22,19 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.stephens.diceroller.R
 import com.stephens.diceroller.ui.theme.DiceRollerTheme
 
 @Composable
-fun MainScreen(viewModel: MainViewModel) {
+fun MainScreen(viewModel: MainViewModel = hiltViewModel<MainViewModel>()) {
     Column (
         modifier = Modifier.fillMaxSize(),
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally
     ){
-        val uiState = viewModel.stateFlow.collectAsState()
+        val uiState = viewModel.stateFlow.collectAsStateWithLifecycle()
         MainContent(
             state = uiState.value,
             tapRoll = { viewModel.postAction(MainAction.TapRoll)}

--- a/app/src/main/java/com/stephens/diceroller/main/MainState.kt
+++ b/app/src/main/java/com/stephens/diceroller/main/MainState.kt
@@ -8,6 +8,5 @@ data class MainState (
 
 sealed class MainAction {
     data object TapRoll : MainAction()
-    data object TapClearHistory: MainAction()
     data object ClearErrors : MainAction()
 }

--- a/app/src/main/java/com/stephens/diceroller/main/MainViewModel.kt
+++ b/app/src/main/java/com/stephens/diceroller/main/MainViewModel.kt
@@ -9,7 +9,6 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.launch
 import java.util.Calendar
 import javax.inject.Inject
@@ -24,7 +23,6 @@ class MainViewModel @Inject constructor(
             field = value
             _stateFlow.tryEmit(value)
         }
-    val historyStateFlow = historyRepository.getHistory().flowOn(Dispatchers.IO)
 
     private val _stateFlow = MutableStateFlow(state)
     val stateFlow = _stateFlow.asStateFlow()
@@ -37,12 +35,6 @@ class MainViewModel @Inject constructor(
                     min = 1,
                     max = 6
                 )
-
-            MainAction.TapClearHistory -> {
-                viewModelScope.launch(Dispatchers.IO) {
-                    historyRepository.clearHistory()
-                }
-            }
 
             MainAction.ClearErrors ->
                 state = state.copy(


### PR DESCRIPTION
- Added `HistoryState` and HistoryViewModel`, removed relevant history elements from `MainViewModel`
- Added preview from `HistoryScreen`
- Removed viewModel declarations from `DiceRollerAppComposable`
- Injected viewModels into screen composables with hilt
- Set history `LazyColumn` to be at the top (most recent result) by default